### PR TITLE
Included constraint abstract and manager

### DIFF
--- a/bindings/python/crocoddyl/core/constraint-base.cpp
+++ b/bindings/python/crocoddyl/core/constraint-base.cpp
@@ -1,0 +1,105 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2020, University of Edinburgh
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#include "python/crocoddyl/core/core.hpp"
+#include "python/crocoddyl/core/constraint-base.hpp"
+
+namespace crocoddyl {
+namespace python {
+
+void exposeConstraintAbstract() {
+  bp::register_ptr_to_python<boost::shared_ptr<ConstraintModelAbstract> >();
+
+  bp::class_<ConstraintModelAbstract_wrap, boost::noncopyable>(
+      "ConstraintModelAbstract",
+      "Abstract multibody constraint models.\n\n"
+      "In Crocoddyl, a constraint model defines both: inequality g(x,u) and equality h(x, u) constraints.\n"
+      "The constraint function depends on the state point x, which lies in the state manifold\n"
+      "described with a nq-tuple, its velocity xd that belongs to the tangent space with nv dimension,\n"
+      "and the control input u.",
+      bp::init<boost::shared_ptr<StateAbstract>, int, int, int>(
+          bp::args("self", "state", "nu", "ng", "nh"),
+          "Initialize the constraint model.\n\n"
+          ":param state: state description\n"
+          ":param nu: dimension of control vector (default state.nv)\n"
+          ":param ng: number of inequality constraints\n"
+          ":param nh: number of equality constraints"))
+      .def(bp::init<boost::shared_ptr<StateAbstract>, int, int>(bp::args("self", "state", "ng", "nh"),
+                                                                "Initialize the constraint model.\n\n"
+                                                                ":param state: state description\n"
+                                                                ":param ng: number of inequality constraints\n"
+                                                                ":param nh: number of equality constraints"))
+      .def("calc", pure_virtual(&ConstraintModelAbstract_wrap::calc), bp::args("self", "data", "x", "u"),
+           "Compute the constraint value.\n\n"
+           ":param data: constraint data\n"
+           ":param x: state vector\n"
+           ":param u: control input")
+      .def<void (ConstraintModelAbstract::*)(const boost::shared_ptr<ConstraintDataAbstract>&,
+                                             const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &ConstraintModelAbstract::calc, bp::args("self", "data", "x"))
+      .def("calcDiff", pure_virtual(&ConstraintModelAbstract_wrap::calcDiff), bp::args("self", "data", "x", "u"),
+           "Compute the derivatives of the constraint function and its residuals.\n\n"
+           ":param data: constraint data\n"
+           ":param x: state vector\n"
+           ":param u: control input\n")
+      .def<void (ConstraintModelAbstract::*)(const boost::shared_ptr<ConstraintDataAbstract>&,
+                                             const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &ConstraintModelAbstract::calcDiff, bp::args("self", "data", "x"))
+      .def("createData", &ConstraintModelAbstract_wrap::createData, bp::with_custodian_and_ward_postcall<0, 2>(),
+           bp::args("self", "data"),
+           "Create the constraint data.\n\n"
+           "Each constraint model has its own data that needs to be allocated. This function\n"
+           "returns the allocated data for a predefined constraint.\n"
+           ":param data: shared data\n"
+           ":return constraint data.")
+      .def("createData", &ConstraintModelAbstract_wrap::default_createData,
+           bp::with_custodian_and_ward_postcall<0, 2>())
+      .add_property(
+          "state",
+          bp::make_function(&ConstraintModelAbstract_wrap::get_state, bp::return_value_policy<bp::return_by_value>()),
+          "state description")
+      .add_property(
+          "nu",
+          bp::make_function(&ConstraintModelAbstract_wrap::get_nu, bp::return_value_policy<bp::return_by_value>()),
+          "dimension of control vector")
+      .add_property(
+          "ng",
+          bp::make_function(&ConstraintModelAbstract_wrap::get_ng, bp::return_value_policy<bp::return_by_value>()),
+          "number of inequality constraints")
+      .add_property(
+          "nh",
+          bp::make_function(&ConstraintModelAbstract_wrap::get_nh, bp::return_value_policy<bp::return_by_value>()),
+          "number of equality constraints");
+
+  bp::register_ptr_to_python<boost::shared_ptr<ConstraintDataAbstract> >();
+
+  bp::class_<ConstraintDataAbstract, boost::noncopyable>(
+      "ConstraintDataAbstract", "Abstract class for constraint data.\n\n",
+      bp::init<ConstraintModelAbstract*, DataCollectorAbstract*>(
+          bp::args("self", "model", "data"),
+          "Create common data shared between constraint models.\n\n"
+          ":param model: constraint model\n"
+          ":param data: shared data")[bp::with_custodian_and_ward<1, 2, bp::with_custodian_and_ward<1, 3> >()])
+      .add_property("shared", bp::make_getter(&ConstraintDataAbstract::shared, bp::return_internal_reference<>()),
+                    "shared data")
+      .add_property("g", bp::make_getter(&ConstraintDataAbstract::g, bp::return_internal_reference<>()),
+                    bp::make_setter(&ConstraintDataAbstract::g), "inequality constraint residual")
+      .add_property("Gx", bp::make_getter(&ConstraintDataAbstract::Gx, bp::return_internal_reference<>()),
+                    bp::make_setter(&ConstraintDataAbstract::Gx), "Jacobian of the inequality constraint")
+      .add_property("Gu", bp::make_getter(&ConstraintDataAbstract::Gu, bp::return_internal_reference<>()),
+                    bp::make_setter(&ConstraintDataAbstract::Gu), "Jacobian of the inequality constraint")
+      .add_property("h", bp::make_getter(&ConstraintDataAbstract::h, bp::return_internal_reference<>()),
+                    bp::make_setter(&ConstraintDataAbstract::h), "equality constraint residual")
+      .add_property("Hx", bp::make_getter(&ConstraintDataAbstract::Hx, bp::return_internal_reference<>()),
+                    bp::make_setter(&ConstraintDataAbstract::Hx), "Jacobian of the equality constraint")
+      .add_property("Hu", bp::make_getter(&ConstraintDataAbstract::Hu, bp::return_internal_reference<>()),
+                    bp::make_setter(&ConstraintDataAbstract::Hu), "Jacobian of the equality constraint");
+}
+
+}  // namespace python
+}  // namespace crocoddyl

--- a/bindings/python/crocoddyl/core/constraint-base.hpp
+++ b/bindings/python/crocoddyl/core/constraint-base.hpp
@@ -1,0 +1,68 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2020, University of Edinburgh
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef BINDINGS_PYTHON_CROCODDYL_CORE_CONSTRAINT_BASE_HPP_
+#define BINDINGS_PYTHON_CROCODDYL_CORE_CONSTRAINT_BASE_HPP_
+
+#include "crocoddyl/core/constraint-base.hpp"
+#include "crocoddyl/core/utils/exception.hpp"
+
+namespace crocoddyl {
+namespace python {
+
+class ConstraintModelAbstract_wrap : public ConstraintModelAbstract, public bp::wrapper<ConstraintModelAbstract> {
+ public:
+  ConstraintModelAbstract_wrap(boost::shared_ptr<StateAbstract> state, const std::size_t& nu, const std::size_t& ng,
+                               const std::size_t& nh)
+      : ConstraintModelAbstract(state, nu, ng, nh), bp::wrapper<ConstraintModelAbstract>() {}
+
+  ConstraintModelAbstract_wrap(boost::shared_ptr<StateAbstract> state, const std::size_t& ng, const std::size_t& nh)
+      : ConstraintModelAbstract(state, ng, nh) {}
+
+  void calc(const boost::shared_ptr<ConstraintDataAbstract>& data, const Eigen::Ref<const Eigen::VectorXd>& x,
+            const Eigen::Ref<const Eigen::VectorXd>& u) {
+    if (static_cast<std::size_t>(x.size()) != state_->get_nx()) {
+      throw_pretty("Invalid argument: "
+                   << "x has wrong dimension (it should be " + std::to_string(state_->get_nx()) + ")");
+    }
+    if (static_cast<std::size_t>(u.size()) != nu_) {
+      throw_pretty("Invalid argument: "
+                   << "u has wrong dimension (it should be " + std::to_string(nu_) + ")");
+    }
+    return bp::call<void>(this->get_override("calc").ptr(), data, (Eigen::VectorXd)x, (Eigen::VectorXd)u);
+  }
+
+  void calcDiff(const boost::shared_ptr<ConstraintDataAbstract>& data, const Eigen::Ref<const Eigen::VectorXd>& x,
+                const Eigen::Ref<const Eigen::VectorXd>& u) {
+    if (static_cast<std::size_t>(x.size()) != state_->get_nx()) {
+      throw_pretty("Invalid argument: "
+                   << "x has wrong dimension (it should be " + std::to_string(state_->get_nx()) + ")");
+    }
+    if (static_cast<std::size_t>(u.size()) != nu_) {
+      throw_pretty("Invalid argument: "
+                   << "u has wrong dimension (it should be " + std::to_string(nu_) + ")");
+    }
+    return bp::call<void>(this->get_override("calcDiff").ptr(), data, (Eigen::VectorXd)x, (Eigen::VectorXd)u);
+  }
+
+  boost::shared_ptr<ConstraintDataAbstract> createData(DataCollectorAbstract* const data) {
+    if (boost::python::override createData = this->get_override("createData")) {
+      return bp::call<boost::shared_ptr<ConstraintDataAbstract> >(createData.ptr(), boost::ref(data));
+    }
+    return ConstraintModelAbstract::createData(data);
+  }
+
+  boost::shared_ptr<ConstraintDataAbstract> default_createData(DataCollectorAbstract* const data) {
+    return this->ConstraintModelAbstract::createData(data);
+  }
+};
+
+}  // namespace python
+}  // namespace crocoddyl
+
+#endif  // BINDINGS_PYTHON_CROCODDYL_CORE_CONSTRAINT_BASE_HPP_

--- a/bindings/python/crocoddyl/core/constraints/constraint-manager.cpp
+++ b/bindings/python/crocoddyl/core/constraints/constraint-manager.cpp
@@ -1,0 +1,189 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2020, University of Edinburgh
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <utility>
+#include <string>
+#include "python/crocoddyl/core/core.hpp"
+#include "python/crocoddyl/core/action-base.hpp"
+#include "python/crocoddyl/core/diff-action-base.hpp"
+#include "python/crocoddyl/utils/map-converter.hpp"
+#include "crocoddyl/core/constraints/constraint-manager.hpp"
+
+namespace crocoddyl {
+namespace python {
+
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(ConstraintModelManager_addConstraint_wrap,
+                                       ConstraintModelManager::addConstraint, 2, 3)
+
+void exposeConstraintManager() {
+  // Register custom converters between std::map and Python dict
+  typedef boost::shared_ptr<ConstraintItem> ConstraintItemPtr;
+  typedef boost::shared_ptr<ConstraintDataAbstract> ConstraintDataPtr;
+  StdMapPythonVisitor<std::string, ConstraintItemPtr, std::less<std::string>,
+                      std::allocator<std::pair<const std::string, ConstraintItemPtr> >,
+                      true>::expose("StdMap_ConstraintItem");
+  StdMapPythonVisitor<std::string, ConstraintDataPtr, std::less<std::string>,
+                      std::allocator<std::pair<const std::string, ConstraintDataPtr> >,
+                      true>::expose("StdMap_ConstraintData");
+
+  bp::register_ptr_to_python<boost::shared_ptr<ConstraintItem> >();
+
+  bp::class_<ConstraintItem>("ConstraintItem", "Describe a constraint item.\n\n",
+                             bp::init<std::string, boost::shared_ptr<ConstraintModelAbstract>, bp::optional<bool> >(
+                                 bp::args("self", "name", "constraint", "active"),
+                                 "Initialize the constraint item.\n\n"
+                                 ":param name: constraint name\n"
+                                 ":param constraint: constraint model\n"
+                                 ":param active: True if the constraint is activated (default true)"))
+      .def_readwrite("name", &ConstraintItem::name, "constraint name")
+      .add_property("constraint",
+                    bp::make_getter(&ConstraintItem::constraint, bp::return_value_policy<bp::return_by_value>()),
+                    "constraint model")
+      .def_readwrite("active", &ConstraintItem::active, "constraint status");
+  ;
+
+  bp::register_ptr_to_python<boost::shared_ptr<ConstraintModelManager> >();
+
+  bp::class_<ConstraintModelManager>("ConstraintModelManager", bp::init<boost::shared_ptr<StateAbstract>, std::size_t>(
+                                                                   bp::args("self", "state", "nu"),
+                                                                   "Initialize the total constraint model.\n\n"
+                                                                   ":param state: state description\n"
+                                                                   ":param nu: dimension of control vector"))
+      .def(bp::init<boost::shared_ptr<StateAbstract>, std::size_t>(
+          bp::args("self", "state", "nu"),
+          "Initialize the total constraint model.\n\n"
+          "For this case the default nu is equals to model.nv.\n"
+          ":param state: state description\n"
+          ":param nu: dimension of control vector"))
+      .def(bp::init<boost::shared_ptr<StateAbstract> >(bp::args("self", "state"),
+                                                       "Initialize the total constraint model.\n\n"
+                                                       "For this case the default nu is equals to model.nv.\n"
+                                                       ":param state: state description"))
+      .def("addConstraint", &ConstraintModelManager::addConstraint,
+           ConstraintModelManager_addConstraint_wrap(
+               bp::args("self", "name", "constraint", "active"),
+               "Add a constraint item.\n\n"
+               ":param name: constraint name\n"
+               ":param constraint: constraint model\n"
+               ":param active: True if the constraint is activated (default true)"))
+      .def("removeConstraint", &ConstraintModelManager::removeConstraint, bp::args("self", "name"),
+           "Remove a constraint item.\n\n"
+           ":param name: constraint name")
+      .def("changeConstraintStatus", &ConstraintModelManager::changeConstraintStatus,
+           bp::args("self", "name", "active"),
+           "Change the constraint status.\n\n"
+           ":param name: constraint name\n"
+           ":param active: constraint status (true for active and false for inactive)")
+      .def<void (ConstraintModelManager::*)(const boost::shared_ptr<ConstraintDataManager>&,
+                                            const Eigen::Ref<const Eigen::VectorXd>&,
+                                            const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &ConstraintModelManager::calc, bp::args("self", "data", "x", "u"),
+          "Compute the total constraint.\n\n"
+          ":param data: constraint-sum data\n"
+          ":param x: time-discrete state vector\n"
+          ":param u: time-discrete control input")
+      .def<void (ConstraintModelManager::*)(const boost::shared_ptr<ConstraintDataManager>&,
+                                            const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &ConstraintModelManager::calc, bp::args("self", "data", "x"))
+      .def<void (ConstraintModelManager::*)(const boost::shared_ptr<ConstraintDataManager>&,
+                                            const Eigen::Ref<const Eigen::VectorXd>&,
+                                            const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &ConstraintModelManager::calcDiff, bp::args("self", "data", "x", "u"),
+          "Compute the derivatives of the total constraint.\n\n"
+          ":param data: action data\n"
+          ":param x: time-discrete state vector\n"
+          ":param u: time-discrete control input\n")
+      .def<void (ConstraintModelManager::*)(const boost::shared_ptr<ConstraintDataManager>&,
+                                            const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &ConstraintModelManager::calcDiff, bp::args("self", "data", "x"))
+      .def("createData", &ConstraintModelManager::createData, bp::with_custodian_and_ward_postcall<0, 2>(),
+           bp::args("self", "data"),
+           "Create the total constraint data.\n\n"
+           ":param data: shared data\n"
+           ":return total constraint data.")
+      .add_property(
+          "state",
+          bp::make_function(&ConstraintModelManager::get_state, bp::return_value_policy<bp::return_by_value>()),
+          "state description")
+      .add_property(
+          "constraints",
+          bp::make_function(&ConstraintModelManager::get_constraints, bp::return_value_policy<bp::return_by_value>()),
+          "stack of constraints")
+      .add_property("nu",
+                    bp::make_function(&ConstraintModelManager::get_nu, bp::return_value_policy<bp::return_by_value>()),
+                    "dimension of control vector")
+      .add_property("ng",
+                    bp::make_function(&ConstraintModelManager::get_ng, bp::return_value_policy<bp::return_by_value>()),
+                    "number of active inequality constraints")
+      .add_property("nh",
+                    bp::make_function(&ConstraintModelManager::get_nh, bp::return_value_policy<bp::return_by_value>()),
+                    "number of active equality constraints")
+      .add_property(
+          "ng_total",
+          bp::make_function(&ConstraintModelManager::get_ng_total, bp::return_value_policy<bp::return_by_value>()),
+          "number of the total inequality constraints")
+      .add_property(
+          "nh_total",
+          bp::make_function(&ConstraintModelManager::get_nh_total, bp::return_value_policy<bp::return_by_value>()),
+          "number of the total equality constraints")
+      .add_property(
+          "active",
+          bp::make_function(&ConstraintModelManager::get_active, bp::return_value_policy<bp::return_by_value>()),
+          "name of active constraint items")
+      .add_property(
+          "inactive",
+          bp::make_function(&ConstraintModelManager::get_inactive, bp::return_value_policy<bp::return_by_value>()),
+          "name of inactive constraint items")
+      .def("getConstraintStatus", &ConstraintModelManager::getConstraintStatus, bp::args("self", "name"),
+           "Return the constraint status of a given constraint name.\n\n"
+           ":param name: constraint name");
+
+  bp::register_ptr_to_python<boost::shared_ptr<ConstraintDataManager> >();
+
+  bp::class_<ConstraintDataManager>("ConstraintDataManager", "Class for total constraint data.\n\n",
+                                    bp::init<ConstraintModelManager*, DataCollectorAbstract*>(
+                                        bp::args("self", "model", "data"),
+                                        "Create total constraint data.\n\n"
+                                        ":param model: total constraint model\n"
+                                        ":param data: shared data")[bp::with_custodian_and_ward<1, 3>()])
+      .def("shareMemory", &ConstraintDataManager::shareMemory<DifferentialActionDataAbstract>,
+           bp::args("self", "model"),
+           "Share memory with a given differential action data\n\n"
+           ":param model: differential action data that we want to share memory")
+      .def("shareMemory", &ConstraintDataManager::shareMemory<ActionDataAbstract>, bp::args("self", "model"),
+           "Share memory with a given action data\n\n"
+           ":param model: action data that we want to share memory")
+      .add_property(
+          "constraints",
+          bp::make_getter(&ConstraintDataManager::constraints, bp::return_value_policy<bp::return_by_value>()),
+          "stack of constraints data")
+      .add_property("shared", bp::make_getter(&ConstraintDataManager::shared, bp::return_internal_reference<>()),
+                    "shared data")
+      .add_property("g", bp::make_getter(&ConstraintDataManager::g, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_setter(&ConstraintDataManager::g), "Inequality constraint residual")
+      .add_property("Gx",
+                    bp::make_function(&ConstraintDataManager::get_Gx, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_function(&ConstraintDataManager::set_Gx), "Jacobian of the inequality constraint")
+      .add_property("Gu",
+                    bp::make_function(&ConstraintDataManager::get_Gu, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_function(&ConstraintDataManager::set_Gu), "Jacobian of the inequality constraint")
+      .add_property("h", bp::make_getter(&ConstraintDataManager::h, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_setter(&ConstraintDataManager::h), "Equality constraint residual")
+      .add_property("Hx",
+                    bp::make_function(&ConstraintDataManager::get_Hx, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_function(&ConstraintDataManager::set_Hx), "Jacobian of the equality constraint")
+      .add_property("Hu",
+                    bp::make_function(&ConstraintDataManager::get_Hu, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_function(&ConstraintDataManager::set_Hu), "Jacobian of the equality constraint");
+}
+
+}  // namespace python
+}  // namespace crocoddyl

--- a/bindings/python/crocoddyl/core/core.cpp
+++ b/bindings/python/crocoddyl/core/core.cpp
@@ -28,6 +28,7 @@ void exposeCore() {
   exposeCostSum();
   exposeCostControl();
   exposeConstraintAbstract();
+  exposeConstraintManager();
   exposeActionNumDiff();
   exposeDifferentialActionNumDiff();
   exposeActivationNumDiff();

--- a/bindings/python/crocoddyl/core/core.cpp
+++ b/bindings/python/crocoddyl/core/core.cpp
@@ -27,6 +27,7 @@ void exposeCore() {
   exposeCostAbstract();
   exposeCostSum();
   exposeCostControl();
+  exposeConstraintAbstract();
   exposeActionNumDiff();
   exposeDifferentialActionNumDiff();
   exposeActivationNumDiff();

--- a/bindings/python/crocoddyl/core/core.hpp
+++ b/bindings/python/crocoddyl/core/core.hpp
@@ -29,6 +29,7 @@ void exposeIntegratedActionRK4();
 void exposeCostAbstract();
 void exposeCostSum();
 void exposeCostControl();
+void exposeConstraintAbstract();
 void exposeActionNumDiff();
 void exposeDifferentialActionNumDiff();
 void exposeActivationNumDiff();

--- a/bindings/python/crocoddyl/core/core.hpp
+++ b/bindings/python/crocoddyl/core/core.hpp
@@ -30,6 +30,7 @@ void exposeCostAbstract();
 void exposeCostSum();
 void exposeCostControl();
 void exposeConstraintAbstract();
+void exposeConstraintManager();
 void exposeActionNumDiff();
 void exposeDifferentialActionNumDiff();
 void exposeActivationNumDiff();

--- a/bindings/python/crocoddyl/core/cost-base.cpp
+++ b/bindings/python/crocoddyl/core/cost-base.cpp
@@ -100,7 +100,7 @@ void exposeCostAbstract() {
                     "shared data")
       .add_property("activation",
                     bp::make_getter(&CostDataAbstract::activation, bp::return_value_policy<bp::return_by_value>()),
-                    "terminal data")
+                    "activation data")
       .add_property("cost", bp::make_getter(&CostDataAbstract::cost, bp::return_value_policy<bp::return_by_value>()),
                     bp::make_setter(&CostDataAbstract::cost), "cost value")
       .add_property("Lx", bp::make_getter(&CostDataAbstract::Lx, bp::return_internal_reference<>()),

--- a/bindings/python/crocoddyl/core/cost-base.cpp
+++ b/bindings/python/crocoddyl/core/cost-base.cpp
@@ -26,7 +26,7 @@ void exposeCostAbstract() {
       "and the control input u. The dimension of the residual vector is defined by nr, which belongs to\n"
       "the Euclidean space. On the other hand, the activation function builds a cost value based on the\n"
       "definition of the residual vector. The residual vector has to be specialized in a derived classes.",
-      bp::init<boost::shared_ptr<StateAbstract>, boost::shared_ptr<ActivationModelAbstract>, int>(
+      bp::init<boost::shared_ptr<StateAbstract>, boost::shared_ptr<ActivationModelAbstract>, std::size_t>(
           bp::args("self", "state", "activation", "nu"),
           "Initialize the cost model.\n\n"
           ":param state: state description\n"
@@ -37,14 +37,14 @@ void exposeCostAbstract() {
           "Initialize the cost model.\n\n"
           ":param state: state description\n"
           ":param activation: Activation model"))
-      .def(bp::init<boost::shared_ptr<StateAbstract>, int, int>(
+      .def(bp::init<boost::shared_ptr<StateAbstract>, std::size_t, std::size_t>(
           bp::args("self", "state", "nr", "nu"),
           "Initialize the cost model.\n\n"
           "We use ActivationModelQuad as a default activation model (i.e. a=0.5*||r||^2).\n"
           ":param state: state description\n"
           ":param nr: dimension of residual vector\n"
           ":param nu: dimension of control vector (default state.nv)"))
-      .def(bp::init<boost::shared_ptr<StateAbstract>, int>(
+      .def(bp::init<boost::shared_ptr<StateAbstract>, std::size_t>(
           bp::args("self", "state", "nr"),
           "Initialize the cost model.\n\n"
           "We use ActivationModelQuad as a default activation model (i.e. a=0.5*||r||^2), and the default nu value is "

--- a/bindings/python/crocoddyl/core/cost-base.hpp
+++ b/bindings/python/crocoddyl/core/cost-base.hpp
@@ -10,6 +10,7 @@
 #define BINDINGS_PYTHON_CROCODDYL_CORE_COST_BASE_HPP_
 
 #include "crocoddyl/core/cost-base.hpp"
+#include "crocoddyl/core/utils/to-string.hpp"
 #include "crocoddyl/core/utils/exception.hpp"
 
 namespace crocoddyl {
@@ -32,15 +33,27 @@ class CostModelAbstract_wrap : public CostModelAbstract, public bp::wrapper<Cost
 
   void calc(const boost::shared_ptr<CostDataAbstract>& data, const Eigen::Ref<const Eigen::VectorXd>& x,
             const Eigen::Ref<const Eigen::VectorXd>& u) {
-    assert_pretty(static_cast<std::size_t>(x.size()) == state_->get_nx(), "x has wrong dimension");
-    assert_pretty((static_cast<std::size_t>(u.size()) == nu_ || nu_ == 0), "u has wrong dimension");
+    if (static_cast<std::size_t>(x.size()) != state_->get_nx()) {
+      throw_pretty("Invalid argument: "
+                   << "x has wrong dimension (it should be " + std::to_string(state_->get_nx()) + ")");
+    }
+    if (static_cast<std::size_t>(u.size()) != nu_) {
+      throw_pretty("Invalid argument: "
+                   << "u has wrong dimension (it should be " + std::to_string(nu_) + ")");
+    }
     return bp::call<void>(this->get_override("calc").ptr(), data, (Eigen::VectorXd)x, (Eigen::VectorXd)u);
   }
 
   void calcDiff(const boost::shared_ptr<CostDataAbstract>& data, const Eigen::Ref<const Eigen::VectorXd>& x,
                 const Eigen::Ref<const Eigen::VectorXd>& u) {
-    assert_pretty(static_cast<std::size_t>(x.size()) == state_->get_nx(), "x has wrong dimension");
-    assert_pretty((static_cast<std::size_t>(u.size()) == nu_ || nu_ == 0), "u has wrong dimension");
+    if (static_cast<std::size_t>(x.size()) != state_->get_nx()) {
+      throw_pretty("Invalid argument: "
+                   << "x has wrong dimension (it should be " + std::to_string(state_->get_nx()) + ")");
+    }
+    if (static_cast<std::size_t>(u.size()) != nu_) {
+      throw_pretty("Invalid argument: "
+                   << "u has wrong dimension (it should be " + std::to_string(nu_) + ")");
+    }
     return bp::call<void>(this->get_override("calcDiff").ptr(), data, (Eigen::VectorXd)x, (Eigen::VectorXd)u);
   }
 

--- a/bindings/python/crocoddyl/core/costs/cost-sum.cpp
+++ b/bindings/python/crocoddyl/core/costs/cost-sum.cpp
@@ -67,11 +67,11 @@ void exposeCostSum() {
                                                        ":param state: state description"))
       .def("addCost", &CostModelSum::addCost,
            CostModelSum_addCost_wrap(bp::args("self", "name", "cost", "weight", "active"),
-                                        "Add a cost item.\n\n"
-                                        ":param name: cost name\n"
-                                        ":param cost: cost model\n"
-                                        ":param weight: cost weight\n"
-                                        ":param active: True if the cost is activated (default true)"))
+                                     "Add a cost item.\n\n"
+                                     ":param name: cost name\n"
+                                     ":param cost: cost model\n"
+                                     ":param weight: cost weight\n"
+                                     ":param active: True if the cost is activated (default true)"))
       .def("removeCost", &CostModelSum::removeCost, bp::args("self", "name"),
            "Remove a cost item.\n\n"
            ":param name: cost name")

--- a/bindings/python/crocoddyl/core/costs/cost-sum.cpp
+++ b/bindings/python/crocoddyl/core/costs/cost-sum.cpp
@@ -59,8 +59,7 @@ void exposeCostSum() {
           "Initialize the total cost model.\n\n"
           "For this case the default nu is equals to model.nv.\n"
           ":param state: state description\n"
-          ":param nu: dimension of control vector\n"
-          ":param withResiduals: true if the cost function has residuals"))
+          ":param nu: dimension of control vector"))
       .def(bp::init<boost::shared_ptr<StateAbstract> >(bp::args("self", "state"),
                                                        "Initialize the total cost model.\n\n"
                                                        "For this case the default nu is equals to model.nv.\n"
@@ -104,7 +103,7 @@ void exposeCostSum() {
            ":return total cost data.")
       .add_property("state",
                     bp::make_function(&CostModelSum::get_state, bp::return_value_policy<bp::return_by_value>()),
-                    "state of the multibody system")
+                    "state description")
       .add_property("costs",
                     bp::make_function(&CostModelSum::get_costs, bp::return_value_policy<bp::return_by_value>()),
                     "stack of costs")

--- a/bindings/python/crocoddyl/core/costs/cost-sum.cpp
+++ b/bindings/python/crocoddyl/core/costs/cost-sum.cpp
@@ -20,7 +20,7 @@
 namespace crocoddyl {
 namespace python {
 
-BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(CostModelSum_addContact_wrap, CostModelSum::addCost, 3, 4)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(CostModelSum_addCost_wrap, CostModelSum::addCost, 3, 4)
 
 void exposeCostSum() {
   // Register custom converters between std::map and Python dict
@@ -46,7 +46,6 @@ void exposeCostSum() {
                     "cost model")
       .def_readwrite("weight", &CostItem::weight, "cost weight")
       .def_readwrite("active", &CostItem::active, "cost status");
-  ;
 
   bp::register_ptr_to_python<boost::shared_ptr<CostModelSum> >();
 
@@ -67,7 +66,7 @@ void exposeCostSum() {
                                                        "For this case the default nu is equals to model.nv.\n"
                                                        ":param state: state description"))
       .def("addCost", &CostModelSum::addCost,
-           CostModelSum_addContact_wrap(bp::args("self", "name", "cost", "weight", "active"),
+           CostModelSum_addCost_wrap(bp::args("self", "name", "cost", "weight", "active"),
                                         "Add a cost item.\n\n"
                                         ":param name: cost name\n"
                                         ":param cost: cost model\n"

--- a/include/crocoddyl/core/constraint-base.hpp
+++ b/include/crocoddyl/core/constraint-base.hpp
@@ -1,0 +1,215 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2020, University of Edinburgh
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef CROCODDYL_CORE_CONSTRAINT_BASE_HPP_
+#define CROCODDYL_CORE_CONSTRAINT_BASE_HPP_
+
+#include <boost/shared_ptr.hpp>
+#include <boost/make_shared.hpp>
+
+#include "crocoddyl/core/fwd.hpp"
+#include "crocoddyl/core/state-base.hpp"
+#include "crocoddyl/core/data-collector-base.hpp"
+
+namespace crocoddyl {
+
+/**
+ * @brief Abstract class for constraint models
+ *
+ * In Crocoddyl, a constraint model defines both: inequality \f$\mathbf{g}(\mathbf{x}, \mathbf{u})\in\mathbb{R}^{ng}\f$
+ * and equality \f$\mathbf{h}(\mathbf{x}, \mathbf{u})\in\mathbb{R}^{nh}\f$ constraints.
+ * The constraint function depends on the state point \f$\mathbf{x}\in\mathcal{X}\f$, which lies in the state manifold
+ * described with a `nq`-tuple, its velocity \f$\dot{\mathbf{x}}\in T_{\mathbf{x}}\mathcal{X}\f$ that belongs to
+ * the tangent space with `nv` dimension, and the control input \f$\mathbf{u}\in\mathbb{R}^{nu}\f$.
+ *
+ * The main computations are carring out in `calc` and `calcDiff` routines. `calc` computes the constraint residual and
+ * `calcDiff` computes the Jacobians of the constraint function. Concretely speaking, `calcDiff` builds
+ * a linear approximation of the constraint function with the form: \f$\mathbf{g_x}\in\mathbb{R}^{ng\times ndx}\f$,
+ * \f$\mathbf{g_u}\in\mathbb{R}^{ng\times nu}\f$, \f$\mathbf{h_x}\in\mathbb{R}^{nh\times ndx}\f$
+ * \f$\mathbf{h_u}\in\mathbb{R}^{nh\times nu}\f$.
+ *
+ * \sa `StateAbstractTpl`, `calc()`, `calcDiff()`, `createData()`
+ */
+template <typename _Scalar>
+class ConstraintModelAbstractTpl {
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  typedef _Scalar Scalar;
+  typedef MathBaseTpl<Scalar> MathBase;
+  typedef ConstraintDataAbstractTpl<Scalar> ConstraintDataAbstract;
+  typedef StateAbstractTpl<Scalar> StateAbstract;
+  typedef DataCollectorAbstractTpl<Scalar> DataCollectorAbstract;
+  typedef typename MathBase::VectorXs VectorXs;
+
+  /**
+   * @brief Initialize the constraint model
+   *
+   * @param[in] state  State of the multibody system
+   * @param[in] nu     Dimension of control vector
+   * @param[in] ng     Number of inequality constraints
+   * @param[in] nh     Number of equality constraints
+   */
+  ConstraintModelAbstractTpl(boost::shared_ptr<StateAbstract> state, const std::size_t& nu, const std::size_t& ng,
+                             const std::size_t& nh);
+
+  /**
+   * @copybrief ConstraintModelAbstractTpl()
+   *
+   * The default `nu` value is obtained from `StateAbstractTpl::get_nv()`.
+   *
+   * @param[in] state  State of the multibody system
+   * @param[in] ng     Number of inequality constraints
+   * @param[in] nh     Number of equality constraints
+   */
+  ConstraintModelAbstractTpl(boost::shared_ptr<StateAbstract> state, const std::size_t& ng, const std::size_t& nh);
+  virtual ~ConstraintModelAbstractTpl();
+
+  /**
+   * @brief Compute the constraint value and its residual vector
+   *
+   * @param[in] data  Constraint data
+   * @param[in] x     State point \f$\mathbf{x}\in\mathbb{R}^{ndx}\f$
+   * @param[in] u     Control input \f$\mathbf{u}\in\mathbb{R}^{nu}\f$
+   */
+  virtual void calc(const boost::shared_ptr<ConstraintDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
+                    const Eigen::Ref<const VectorXs>& u) = 0;
+
+  /**
+   * @brief Compute the Jacobian of the constraint
+   *
+   * @param[in] data  Constraint data
+   * @param[in] x     State point \f$\mathbf{x}\in\mathbb{R}^{ndx}\f$
+   * @param[in] u     Control input \f$\mathbf{u}\in\mathbb{R}^{nu}\f$
+   */
+  virtual void calcDiff(const boost::shared_ptr<ConstraintDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
+                        const Eigen::Ref<const VectorXs>& u) = 0;
+
+  /**
+   * @brief Create the constraint data
+   *
+   * The default data contains objects to store the values of the constraint, residual vector and their first
+   * derivatives. However, it is possible to specialized this function is we need to create additional data, for
+   * instance, to avoid dynamic memory allocation.
+   *
+   * @param data  Data collector
+   * @return the constraint data
+   */
+  virtual boost::shared_ptr<ConstraintDataAbstract> createData(DataCollectorAbstract* const data);
+
+  /**
+   * @copybrief calc()
+   *
+   * @param[in] data  Constraint data
+   * @param[in] x     State point
+   */
+  void calc(const boost::shared_ptr<ConstraintDataAbstract>& data, const Eigen::Ref<const VectorXs>& x);
+
+  /**
+   * @copybrief calcDiff()
+   *
+   * @param[in] data  Constraint data
+   * @param[in] x     State point
+   */
+  void calcDiff(const boost::shared_ptr<ConstraintDataAbstract>& data, const Eigen::Ref<const VectorXs>& x);
+
+  /**
+   * @brief Return the state
+   */
+  const boost::shared_ptr<StateAbstract>& get_state() const;
+
+  /**
+   * @brief Return the dimension of the control input
+   */
+  const std::size_t& get_nu() const;
+
+  /**
+   * @brief Return the number of inequality constraints
+   */
+  const std::size_t& get_ng() const;
+
+  /**
+   * @brief Return the number of equality constraints
+   */
+  const std::size_t& get_nh() const;
+
+  /**
+   * @brief Modify the constraint reference
+   */
+  template <class ReferenceType>
+  void set_reference(ReferenceType ref);
+
+  /**
+   * @brief Return the constraint reference
+   */
+  template <class ReferenceType>
+  ReferenceType get_reference() const;
+
+ protected:
+  /**
+   * @copybrief set_reference()
+   */
+  virtual void set_referenceImpl(const std::type_info&, const void*);
+
+  /**
+   * @copybrief get_reference()
+   */
+  virtual void get_referenceImpl(const std::type_info&, void*) const;
+
+  boost::shared_ptr<StateAbstract> state_;  //!< State description
+  std::size_t nu_;                          //!< Control dimension
+  std::size_t ng_;                          //!< Number of inequality constraints
+  std::size_t nh_;                          //!< Number of equality constraints
+  VectorXs unone_;                          //!< No control vector
+};
+
+template <typename _Scalar>
+struct ConstraintDataAbstractTpl {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  typedef _Scalar Scalar;
+  typedef MathBaseTpl<Scalar> MathBase;
+  typedef DataCollectorAbstractTpl<Scalar> DataCollectorAbstract;
+  typedef typename MathBase::VectorXs VectorXs;
+  typedef typename MathBase::MatrixXs MatrixXs;
+
+  template <template <typename Scalar> class Model>
+  ConstraintDataAbstractTpl(Model<Scalar>* const model, DataCollectorAbstract* const data)
+      : shared(data),
+        g(model->get_ng()),
+        Gx(model->get_ng(), model->get_state()->get_ndx()),
+        Gu(model->get_ng(), model->get_nu()),
+        h(model->get_nh()),
+        Hx(model->get_nh(), model->get_state()->get_ndx()),
+        Hu(model->get_nh(), model->get_nu()) {
+    g.setZero();
+    Gx.setZero();
+    Gu.setZero();
+    h.setZero();
+    Hx.setZero();
+    Hu.setZero();
+  }
+  virtual ~ConstraintDataAbstractTpl() {}
+
+  DataCollectorAbstract* shared;  //!< Shared data
+  VectorXs g;                     //!< Inequality constraint values
+  MatrixXs Gx;                    //!< Jacobian of the inequality constraint
+  MatrixXs Gu;                    //!< Jacobian of the inequality constraint
+  VectorXs h;                     //!< Equality constraint values
+  MatrixXs Hx;                    //!< Jacobian of the equality constraint
+  MatrixXs Hu;                    //!< Jacobian of the equality constraint
+};
+
+}  // namespace crocoddyl
+
+/* --- Details -------------------------------------------------------------- */
+/* --- Details -------------------------------------------------------------- */
+/* --- Details -------------------------------------------------------------- */
+#include "crocoddyl/core/constraint-base.hxx"
+
+#endif  // CROCODDYL_CORE_CONSTRAINT_BASE_HPP_

--- a/include/crocoddyl/core/constraint-base.hxx
+++ b/include/crocoddyl/core/constraint-base.hxx
@@ -1,0 +1,88 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2020, University of Edinburgh
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+namespace crocoddyl {
+
+template <typename Scalar>
+ConstraintModelAbstractTpl<Scalar>::ConstraintModelAbstractTpl(boost::shared_ptr<StateAbstract> state,
+                                                               const std::size_t& nu, const std::size_t& ng,
+                                                               const std::size_t& nh)
+    : state_(state), nu_(nu), ng_(ng), nh_(nh), unone_(VectorXs::Zero(nu)) {}
+
+template <typename Scalar>
+ConstraintModelAbstractTpl<Scalar>::ConstraintModelAbstractTpl(boost::shared_ptr<StateAbstract> state,
+                                                               const std::size_t& ng, const std::size_t& nh)
+    : state_(state), nu_(state->get_nv()), ng_(ng), nh_(nh), unone_(VectorXs::Zero(state->get_nv())) {}
+
+template <typename Scalar>
+ConstraintModelAbstractTpl<Scalar>::~ConstraintModelAbstractTpl() {}
+
+template <typename Scalar>
+void ConstraintModelAbstractTpl<Scalar>::calc(const boost::shared_ptr<ConstraintDataAbstract>& data,
+                                              const Eigen::Ref<const VectorXs>& x) {
+  calc(data, x, unone_);
+}
+
+template <typename Scalar>
+void ConstraintModelAbstractTpl<Scalar>::calcDiff(const boost::shared_ptr<ConstraintDataAbstract>& data,
+                                                  const Eigen::Ref<const VectorXs>& x) {
+  calcDiff(data, x, unone_);
+}
+
+template <typename Scalar>
+boost::shared_ptr<ConstraintDataAbstractTpl<Scalar> > ConstraintModelAbstractTpl<Scalar>::createData(
+    DataCollectorAbstract* const data) {
+  return boost::allocate_shared<ConstraintDataAbstract>(Eigen::aligned_allocator<ConstraintDataAbstract>(), this,
+                                                        data);
+}
+
+template <typename Scalar>
+const boost::shared_ptr<StateAbstractTpl<Scalar> >& ConstraintModelAbstractTpl<Scalar>::get_state() const {
+  return state_;
+}
+
+template <typename Scalar>
+const std::size_t& ConstraintModelAbstractTpl<Scalar>::get_nu() const {
+  return nu_;
+}
+
+template <typename Scalar>
+const std::size_t& ConstraintModelAbstractTpl<Scalar>::get_ng() const {
+  return ng_;
+}
+
+template <typename Scalar>
+const std::size_t& ConstraintModelAbstractTpl<Scalar>::get_nh() const {
+  return nu_;
+}
+
+template <typename Scalar>
+template <class ReferenceType>
+void ConstraintModelAbstractTpl<Scalar>::set_reference(ReferenceType ref) {
+  set_referenceImpl(typeid(ref), &ref);
+}
+
+template <typename Scalar>
+void ConstraintModelAbstractTpl<Scalar>::set_referenceImpl(const std::type_info&, const void*) {
+  throw_pretty("It has not been implemented the set_referenceImpl() function");
+}
+
+template <typename Scalar>
+template <class ReferenceType>
+ReferenceType ConstraintModelAbstractTpl<Scalar>::get_reference() const {
+  ReferenceType ref;
+  get_referenceImpl(typeid(ref), &ref);
+  return ref;
+}
+
+template <typename Scalar>
+void ConstraintModelAbstractTpl<Scalar>::get_referenceImpl(const std::type_info&, void*) const {
+  throw_pretty("It has not been implemented the set_referenceImpl() function");
+}
+
+}  // namespace crocoddyl

--- a/include/crocoddyl/core/constraints/constraint-manager.hpp
+++ b/include/crocoddyl/core/constraints/constraint-manager.hpp
@@ -1,0 +1,359 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2020, University of Edinburgh
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef CROCODDYL_CORE_COSTS_COST_SUM_HPP_
+#define CROCODDYL_CORE_COSTS_COST_SUM_HPP_
+
+#include <string>
+#include <map>
+#include <utility>
+
+#include "crocoddyl/core/fwd.hpp"
+#include "crocoddyl/core/constraint-base.hpp"
+#include "crocoddyl/core/utils/exception.hpp"
+
+namespace crocoddyl {
+
+template <typename _Scalar>
+struct ConstraintItemTpl {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  typedef _Scalar Scalar;
+  typedef ConstraintModelAbstractTpl<Scalar> ConstraintModelAbstract;
+
+  ConstraintItemTpl() {}
+  ConstraintItemTpl(const std::string& name, boost::shared_ptr<ConstraintModelAbstract> constraint, bool active = true)
+      : name(name), constraint(constraint), active(active) {}
+
+  std::string name;
+  boost::shared_ptr<ConstraintModelAbstract> constraint;
+  bool active;
+};
+
+/**
+ * @brief Manage the individual constraint models
+ *
+ * This class serves to manage a set of added constraint models. The constraint functions might active or inactive,
+ * with this approach we avoid dynamic allocation of memory. Each constraint model is added through `addConstraint`,
+ * where its status can be defined.
+ *
+ * The main computations are carring out in `calc` and `calcDiff` routines. `calc` computes the constraint residuals
+ * and `calcDiff` computes the Jacobians of the constraint functions. Concretely speaking,
+ * `calcDiff` builds a linear approximation of the total constraint function (both inequality and equality) with the
+ * form: \f$\mathbf{g_u}\in\mathbb{R}^{ng\times nu}\f$, \f$\mathbf{h_x}\in\mathbb{R}^{nh\times ndx}\f$
+ * \f$\mathbf{h_u}\in\mathbb{R}^{nh\times nu}\f$.
+ *
+ * \sa `StateAbstractTpl`, `calc()`, `calcDiff()`, `createData()`
+ */
+template <typename _Scalar>
+class ConstraintModelManagerTpl {
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  typedef _Scalar Scalar;
+  typedef MathBaseTpl<Scalar> MathBase;
+  typedef ConstraintDataManagerTpl<Scalar> ConstraintDataManager;
+  typedef StateAbstractTpl<Scalar> StateAbstract;
+  typedef ConstraintModelAbstractTpl<Scalar> ConstraintModelAbstract;
+  typedef ConstraintDataAbstractTpl<Scalar> ConstraintDataAbstract;
+  typedef DataCollectorAbstractTpl<Scalar> DataCollectorAbstract;
+  typedef ConstraintItemTpl<Scalar> ConstraintItem;
+  typedef typename MathBase::VectorXs VectorXs;
+  typedef typename MathBase::MatrixXs MatrixXs;
+
+  typedef std::map<std::string, boost::shared_ptr<ConstraintItem> > ConstraintModelContainer;
+  typedef std::map<std::string, boost::shared_ptr<ConstraintDataAbstract> > ConstraintDataContainer;
+
+  /**
+   * @brief Initialize the constraint-manager model
+   *
+   * @param[in] state  State of the multibody system
+   * @param[in] nu     Dimension of control vector
+   */
+  ConstraintModelManagerTpl(boost::shared_ptr<StateAbstract> state, const std::size_t& nu);
+
+  /**
+   * @brief Initialize the constraint-manager model
+   *
+   * The default `nu` value is obtained from `StateAbstractTpl::get_nv()`.
+   *
+   * @param[in] state  State of the multibody system
+   */
+  explicit ConstraintModelManagerTpl(boost::shared_ptr<StateAbstract> state);
+  ~ConstraintModelManagerTpl();
+
+  /**
+   * @brief Add a constraint item
+   *
+   * @param[in] name        Constraint name
+   * @param[in] constraint  Constraint model
+   * @param[in] weight      Constraint weight
+   * @param[in] active      True if the constraint is activated (default true)
+   */
+  void addConstraint(const std::string& name, boost::shared_ptr<ConstraintModelAbstract> constraint,
+                     bool active = true);
+
+  /**
+   * @brief Remove a constraint item
+   *
+   * @param[in] name  Constraint name
+   */
+  void removeConstraint(const std::string& name);
+
+  /**
+   * @brief Change the constraint status
+   *
+   * @param[in] name    Constraint name
+   * @param[in] active  Constraint status (true for active and false for inactive)
+   */
+  void changeConstraintStatus(const std::string& name, bool active);
+
+  /**
+   * @brief Compute the total constraint value
+   *
+   * @param[in] data  Constraint data
+   * @param[in] x     State point \f$\mathbf{x}\in\mathbb{R}^{ndx}\f$
+   * @param[in] u     Control input \f$\mathbf{u}\in\mathbb{R}^{nu}\f$
+   */
+  void calc(const boost::shared_ptr<ConstraintDataManager>& data, const Eigen::Ref<const VectorXs>& x,
+            const Eigen::Ref<const VectorXs>& u);
+
+  /**
+   * @brief Compute the Jacobian of the total constraint
+   *
+   * @param[in] data  Constraint data
+   * @param[in] x     State point \f$\mathbf{x}\in\mathbb{R}^{ndx}\f$
+   * @param[in] u     Control input \f$\mathbf{u}\in\mathbb{R}^{nu}\f$
+   */
+  void calcDiff(const boost::shared_ptr<ConstraintDataManager>& data, const Eigen::Ref<const VectorXs>& x,
+                const Eigen::Ref<const VectorXs>& u);
+
+  /**
+   * @brief Create the constraint data
+   *
+   * The default data contains objects to store the values of the constraint and their derivatives (i.e. Jacobians).
+   * However, it is possible to specialized this function is we need to create additional data, for instance, to avoid
+   * dynamic memory allocation.
+   *
+   * @param data  Data collector
+   * @return the constraint data
+   */
+  boost::shared_ptr<ConstraintDataManager> createData(DataCollectorAbstract* const data);
+
+  /**
+   * @copybrief calc()
+   *
+   * @param[in] data  Constraint data
+   * @param[in] x     State point
+   */
+  void calc(const boost::shared_ptr<ConstraintDataManager>& data, const Eigen::Ref<const VectorXs>& x);
+
+  /**
+   * @copybrief calcDiff()
+   *
+   * @param[in] data  Constraint data
+   * @param[in] x     State point
+   */
+  void calcDiff(const boost::shared_ptr<ConstraintDataManager>& data, const Eigen::Ref<const VectorXs>& x);
+
+  /**
+   * @brief Return the state
+   */
+  const boost::shared_ptr<StateAbstract>& get_state() const;
+
+  /**
+   * @brief Return the stack of constraint models
+   */
+  const ConstraintModelContainer& get_constraints() const;
+
+  /**
+   * @brief Return the dimension of the control input
+   */
+  const std::size_t& get_nu() const;
+
+  /**
+   * @brief Return the number of active inequality constraints
+   */
+  const std::size_t& get_ng() const;
+
+  /**
+   * @brief Return the number of active equality constraints
+   */
+  const std::size_t& get_nh() const;
+
+  /**
+   * @brief Return the number of total inequality constraints
+   */
+  const std::size_t& get_ng_total() const;
+
+  /**
+   * @brief Return the number of total equality constraints
+   */
+  const std::size_t& get_nh_total() const;
+
+  /**
+   * @brief Return the names of the active constraints
+   */
+  const std::vector<std::string>& get_active() const;
+
+  /**
+   * @brief Return the names of the inactive constraints
+   */
+  const std::vector<std::string>& get_inactive() const;
+
+  /**
+   * @brief Return the status of a given constraint name
+   *
+   * @param[in] name  Constraint name
+   */
+  bool getConstraintStatus(const std::string& name) const;
+
+ private:
+  boost::shared_ptr<StateAbstract> state_;  //!< State description
+  ConstraintModelContainer constraints_;    //!< Stack of constraint items
+  std::size_t nu_;                          //!< Dimension of the control input
+  std::size_t ng_;                          //!< Number of the active inequality constraints
+  std::size_t ng_total_;                    //!< Number of the total inequality constraints
+  std::size_t nh_;                          //!< Number of the active equality constraints
+  std::size_t nh_total_;                    //!< Number of the total equality constraints
+  std::vector<std::string> active_;         //!< Names of the active constraint items
+  std::vector<std::string> inactive_;       //!< Names of the inactive constraint items
+  VectorXs unone_;                          //!< No control vector
+};
+
+template <typename _Scalar>
+struct ConstraintDataManagerTpl {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  typedef _Scalar Scalar;
+  typedef MathBaseTpl<Scalar> MathBase;
+  typedef DataCollectorAbstractTpl<Scalar> DataCollectorAbstract;
+  typedef ConstraintItemTpl<Scalar> ConstraintItem;
+  typedef typename MathBase::VectorXs VectorXs;
+  typedef typename MathBase::MatrixXs MatrixXs;
+
+  template <template <typename Scalar> class Model>
+  ConstraintDataManagerTpl(Model<Scalar>* const model, DataCollectorAbstract* const data)
+      : g_internal(model->get_ng()),
+        Gx_internal(model->get_ng(), model->get_state()->get_ndx()),
+        Gu_internal(model->get_ng(), model->get_nu()),
+        h_internal(model->get_nh()),
+        Hx_internal(model->get_nh(), model->get_state()->get_ndx()),
+        Hu_internal(model->get_nh(), model->get_nu()),
+        shared(data),
+        g(g_internal.data(), model->get_ng()),
+        Gx(Gx_internal.data(), model->get_ng(), model->get_state()->get_ndx()),
+        Gu(Gu_internal.data(), model->get_ng(), model->get_nu()),
+        h(h_internal.data(), model->get_nh()),
+        Hx(Hx_internal.data(), model->get_nh(), model->get_state()->get_ndx()),
+        Hu(Hu_internal.data(), model->get_nh(), model->get_nu()) {
+    g.setZero();
+    Gx.setZero();
+    Gu.setZero();
+    h.setZero();
+    Hx.setZero();
+    Hu.setZero();
+    for (typename ConstraintModelManagerTpl<Scalar>::ConstraintModelContainer::const_iterator it =
+             model->get_constraints().begin();
+         it != model->get_constraints().end(); ++it) {
+      const boost::shared_ptr<ConstraintItem>& item = it->second;
+      constraints.insert(std::make_pair(item->name, item->constraint->createData(data)));
+    }
+  }
+
+  template <class ActionData>
+  void shareMemory(ActionData* const data) {
+    // Share memory with the differential action data
+    new (&g) Eigen::Map<VectorXs>(data->g.data(), data->g.size());
+    new (&Gx) Eigen::Map<MatrixXs>(data->Gx.data(), data->Gx.rows(), data->Gx.cols());
+    new (&Gu) Eigen::Map<MatrixXs>(data->Gu.data(), data->Gu.rows(), data->Gu.cols());
+    new (&h) Eigen::Map<VectorXs>(data->h.data(), data->h.size());
+    new (&Hx) Eigen::Map<MatrixXs>(data->Hx.data(), data->Hx.rows(), data->Hx.cols());
+    new (&Hu) Eigen::Map<MatrixXs>(data->Hu.data(), data->Hu.rows(), data->Hu.cols());
+  }
+
+  VectorXs get_g() const { return g; }
+  MatrixXs get_Gx() const { return Gx; }
+  MatrixXs get_Gu() const { return Gu; }
+  VectorXs get_h() const { return h; }
+  MatrixXs get_Hx() const { return Hx; }
+  MatrixXs get_Hu() const { return Hu; }
+
+  void set_g(const VectorXs& _g) {
+    if (g.size() != _g.size()) {
+      throw_pretty("Invalid argument: "
+                   << "g has wrong dimension (it should be " + std::to_string(g.size()) + ")");
+    }
+    g = _g;
+  }
+  void set_Gx(const MatrixXs& _Gx) {
+    if (Gx.rows() != _Gx.rows() || Gx.cols() != _Gx.cols()) {
+      throw_pretty("Invalid argument: "
+                   << "Gx has wrong dimension (it should be " + std::to_string(Gx.rows()) + ", " +
+                          std::to_string(Gx.cols()) + ")");
+    }
+    Gx = _Gx;
+  }
+  void set_Gu(const MatrixXs& _Gu) {
+    if (Gu.rows() != _Gu.rows() || Gu.cols() != _Gu.cols()) {
+      throw_pretty("Invalid argument: "
+                   << "Gu has wrong dimension (it should be " + std::to_string(Gu.rows()) + ", " +
+                          std::to_string(Gu.cols()) + ")");
+    }
+    Gu = _Gu;
+  }
+  void set_h(const VectorXs& _h) {
+    if (h.size() != _h.size()) {
+      throw_pretty("Invalid argument: "
+                   << "h has wrong dimension (it should be " + std::to_string(h.size()) + ")");
+    }
+    h = _h;
+  }
+  void set_Hx(const MatrixXs& _Hx) {
+    if (Hx.rows() != _Hx.rows() || Hx.cols() != _Hx.cols()) {
+      throw_pretty("Invalid argument: "
+                   << "Hx has wrong dimension (it should be " + std::to_string(Hx.rows()) + ", " +
+                          std::to_string(Hx.cols()) + ")");
+    }
+    Hx = _Hx;
+  }
+  void set_Hu(const MatrixXs& _Hu) {
+    if (Hu.rows() != _Hu.rows() || Hu.cols() != _Hu.cols()) {
+      throw_pretty("Invalid argument: "
+                   << "Hu has wrong dimension (it should be " + std::to_string(Hu.rows()) + ", " +
+                          std::to_string(Hu.cols()) + ")");
+    }
+    Hu = _Hu;
+  }
+
+  // Creates internal data in case we don't share it externally
+  VectorXs g_internal;
+  MatrixXs Gx_internal;
+  MatrixXs Gu_internal;
+  VectorXs h_internal;
+  MatrixXs Hx_internal;
+  MatrixXs Hu_internal;
+
+  typename ConstraintModelManagerTpl<Scalar>::ConstraintDataContainer constraints;
+  DataCollectorAbstract* shared;
+  Eigen::Map<VectorXs> g;
+  Eigen::Map<MatrixXs> Gx;
+  Eigen::Map<MatrixXs> Gu;
+  Eigen::Map<VectorXs> h;
+  Eigen::Map<MatrixXs> Hx;
+  Eigen::Map<MatrixXs> Hu;
+};
+
+}  // namespace crocoddyl
+
+/* --- Details -------------------------------------------------------------- */
+/* --- Details -------------------------------------------------------------- */
+/* --- Details -------------------------------------------------------------- */
+#include "crocoddyl/core/constraints/constraint-manager.hxx"
+
+#endif  // CROCODDYL_CORE_COSTS_COST_SUM_HPP_

--- a/include/crocoddyl/core/constraints/constraint-manager.hxx
+++ b/include/crocoddyl/core/constraints/constraint-manager.hxx
@@ -1,0 +1,264 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2020, University of Edinburgh
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#include <iostream>
+#include "crocoddyl/core/utils/exception.hpp"
+
+namespace crocoddyl {
+
+template <typename Scalar>
+ConstraintModelManagerTpl<Scalar>::ConstraintModelManagerTpl(boost::shared_ptr<StateAbstract> state,
+                                                             const std::size_t& nu)
+    : state_(state), nu_(nu), ng_(0), ng_total_(0), nh_(0), nh_total_(0) {}
+
+template <typename Scalar>
+ConstraintModelManagerTpl<Scalar>::ConstraintModelManagerTpl(boost::shared_ptr<StateAbstract> state)
+    : state_(state), nu_(state->get_nv()), ng_(0), ng_total_(0), nh_(0), nh_total_(0) {}
+
+template <typename Scalar>
+ConstraintModelManagerTpl<Scalar>::~ConstraintModelManagerTpl() {}
+
+template <typename Scalar>
+void ConstraintModelManagerTpl<Scalar>::addConstraint(const std::string& name,
+                                                      boost::shared_ptr<ConstraintModelAbstract> constraint,
+                                                      bool active) {
+  if (constraint->get_nu() != nu_) {
+    throw_pretty(name << " constraint item doesn't have the same control dimension (it should be " +
+                             std::to_string(nu_) + ")");
+  }
+  std::pair<typename ConstraintModelContainer::iterator, bool> ret =
+      constraints_.insert(std::make_pair(name, boost::make_shared<ConstraintItem>(name, constraint, active)));
+  if (ret.second == false) {
+    std::cout << "Warning: we couldn't add the " << name << " constraint item, it already existed." << std::endl;
+  } else if (active) {
+    ng_ += constraint->get_ng();
+    ng_total_ += constraint->get_ng();
+    nh_ += constraint->get_nh();
+    nh_total_ += constraint->get_nh();
+    std::vector<std::string>::iterator it =
+        std::lower_bound(active_.begin(), active_.end(), name, std::less<std::string>());
+    active_.insert(it, name);
+  } else if (!active) {
+    ng_total_ += constraint->get_ng();
+    nh_total_ += constraint->get_nh();
+    std::vector<std::string>::iterator it =
+        std::lower_bound(inactive_.begin(), inactive_.end(), name, std::less<std::string>());
+    inactive_.insert(it, name);
+  }
+}
+
+template <typename Scalar>
+void ConstraintModelManagerTpl<Scalar>::removeConstraint(const std::string& name) {
+  typename ConstraintModelContainer::iterator it = constraints_.find(name);
+  if (it != constraints_.end()) {
+    ng_ -= it->second->constraint->get_ng();
+    ng_total_ -= it->second->constraint->get_ng();
+    nh_ -= it->second->constraint->get_nh();
+    nh_total_ -= it->second->constraint->get_nh();
+    constraints_.erase(it);
+    active_.erase(std::remove(active_.begin(), active_.end(), name), active_.end());
+    inactive_.erase(std::remove(inactive_.begin(), inactive_.end(), name), inactive_.end());
+  } else {
+    std::cout << "Warning: we couldn't remove the " << name << " constraint item, it doesn't exist." << std::endl;
+  }
+}
+
+template <typename Scalar>
+void ConstraintModelManagerTpl<Scalar>::changeConstraintStatus(const std::string& name, bool active) {
+  typename ConstraintModelContainer::iterator it = constraints_.find(name);
+  if (it != constraints_.end()) {
+    if (active && !it->second->active) {
+      ng_ += it->second->constraint->get_ng();
+      nh_ += it->second->constraint->get_nh();
+      std::vector<std::string>::iterator it =
+          std::lower_bound(active_.begin(), active_.end(), name, std::less<std::string>());
+      active_.insert(it, name);
+      inactive_.erase(std::remove(inactive_.begin(), inactive_.end(), name), inactive_.end());
+    } else if (!active && it->second->active) {
+      ng_ -= it->second->constraint->get_ng();
+      nh_ -= it->second->constraint->get_nh();
+      active_.erase(std::remove(active_.begin(), active_.end(), name), active_.end());
+      std::vector<std::string>::iterator it =
+          std::lower_bound(inactive_.begin(), inactive_.end(), name, std::less<std::string>());
+      inactive_.insert(it, name);
+    }
+    it->second->active = active;
+  } else {
+    std::cout << "Warning: we couldn't change the status of the " << name << " constraint item, it doesn't exist."
+              << std::endl;
+  }
+}
+
+template <typename Scalar>
+void ConstraintModelManagerTpl<Scalar>::calc(const boost::shared_ptr<ConstraintDataManager>& data,
+                                             const Eigen::Ref<const VectorXs>& x,
+                                             const Eigen::Ref<const VectorXs>& u) {
+  if (static_cast<std::size_t>(x.size()) != state_->get_nx()) {
+    throw_pretty("Invalid argument: "
+                 << "x has wrong dimension (it should be " + std::to_string(state_->get_nx()) + ")");
+  }
+  if (static_cast<std::size_t>(u.size()) != nu_) {
+    throw_pretty("Invalid argument: "
+                 << "u has wrong dimension (it should be " + std::to_string(nu_) + ")");
+  }
+  if (data->constraints.size() != constraints_.size()) {
+    throw_pretty("Invalid argument: "
+                 << "it doesn't match the number of constraint datas and models");
+  }
+  data->g.setZero();
+  data->h.setZero();
+  std::size_t ng_i = 0;
+  std::size_t nh_i = 0;
+
+  typename ConstraintModelContainer::iterator it_m, end_m;
+  typename ConstraintDataContainer::iterator it_d, end_d;
+  for (it_m = constraints_.begin(), end_m = constraints_.end(), it_d = data->constraints.begin(),
+      end_d = data->constraints.end();
+       it_m != end_m || it_d != end_d; ++it_m, ++it_d) {
+    const boost::shared_ptr<ConstraintItem>& m_i = it_m->second;
+    if (m_i->active) {
+      const boost::shared_ptr<ConstraintDataAbstract>& d_i = it_d->second;
+      assert_pretty(it_m->first == it_d->first, "it doesn't match the constraint name between model and data ("
+                                                    << it_m->first << " != " << it_d->first << ")");
+
+      m_i->constraint->calc(d_i, x, u);
+      const std::size_t& ng = m_i->constraint->get_ng();
+      const std::size_t& nh = m_i->constraint->get_nh();
+      data->g.segment(ng_i, ng) += d_i->g;
+      data->h.segment(nh_i, nh) += d_i->g;
+      ng_i += ng;
+      nh_i += nh;
+    }
+  }
+}
+
+template <typename Scalar>
+void ConstraintModelManagerTpl<Scalar>::calcDiff(const boost::shared_ptr<ConstraintDataManager>& data,
+                                                 const Eigen::Ref<const VectorXs>& x,
+                                                 const Eigen::Ref<const VectorXs>& u) {
+  if (static_cast<std::size_t>(x.size()) != state_->get_nx()) {
+    throw_pretty("Invalid argument: "
+                 << "x has wrong dimension (it should be " + std::to_string(state_->get_nx()) + ")");
+  }
+  if (static_cast<std::size_t>(u.size()) != nu_) {
+    throw_pretty("Invalid argument: "
+                 << "u has wrong dimension (it should be " + std::to_string(nu_) + ")");
+  }
+  if (data->constraints.size() != constraints_.size()) {
+    throw_pretty("Invalid argument: "
+                 << "it doesn't match the number of constraint datas and models");
+  }
+  const std::size_t& ndx = state_->get_ndx();
+  data->Gx.setZero();
+  data->Gu.setZero();
+  data->Hx.setZero();
+  data->Hu.setZero();
+  std::size_t ng_i = 0;
+  std::size_t nh_i = 0;
+
+  typename ConstraintModelContainer::iterator it_m, end_m;
+  typename ConstraintDataContainer::iterator it_d, end_d;
+  for (it_m = constraints_.begin(), end_m = constraints_.end(), it_d = data->constraints.begin(),
+      end_d = data->constraints.end();
+       it_m != end_m || it_d != end_d; ++it_m, ++it_d) {
+    const boost::shared_ptr<ConstraintItem>& m_i = it_m->second;
+    if (m_i->active) {
+      const boost::shared_ptr<ConstraintDataAbstract>& d_i = it_d->second;
+      assert_pretty(it_m->first == it_d->first, "it doesn't match the constraint name between model and data ("
+                                                    << it_m->first << " != " << it_d->first << ")");
+
+      m_i->constraint->calcDiff(d_i, x, u);
+      const std::size_t& ng = m_i->constraint->get_ng();
+      const std::size_t& nh = m_i->constraint->get_nh();
+      data->Gx.block(ng_i, 0, ng, ndx) = d_i->Gx;
+      data->Gu.block(ng_i, 0, ng, nu_) = d_i->Gu;
+      data->Hx.block(nh_i, 0, nh, ndx) = d_i->Hx;
+      data->Hu.block(nh_i, 0, nh, nu_) = d_i->Hu;
+      ng_i += ng;
+      nh_i += nh;
+    }
+  }
+}
+
+template <typename Scalar>
+boost::shared_ptr<ConstraintDataManagerTpl<Scalar> > ConstraintModelManagerTpl<Scalar>::createData(
+    DataCollectorAbstract* const data) {
+  return boost::allocate_shared<ConstraintDataManager>(Eigen::aligned_allocator<ConstraintDataManager>(), this, data);
+}
+
+template <typename Scalar>
+void ConstraintModelManagerTpl<Scalar>::calc(const boost::shared_ptr<ConstraintDataManagerTpl<Scalar> >& data,
+                                             const Eigen::Ref<const VectorXs>& x) {
+  calc(data, x, unone_);
+}
+
+template <typename Scalar>
+void ConstraintModelManagerTpl<Scalar>::calcDiff(const boost::shared_ptr<ConstraintDataManagerTpl<Scalar> >& data,
+                                                 const Eigen::Ref<const VectorXs>& x) {
+  calcDiff(data, x, unone_);
+}
+
+template <typename Scalar>
+const boost::shared_ptr<StateAbstractTpl<Scalar> >& ConstraintModelManagerTpl<Scalar>::get_state() const {
+  return state_;
+}
+
+template <typename Scalar>
+const typename ConstraintModelManagerTpl<Scalar>::ConstraintModelContainer&
+ConstraintModelManagerTpl<Scalar>::get_constraints() const {
+  return constraints_;
+}
+
+template <typename Scalar>
+const std::size_t& ConstraintModelManagerTpl<Scalar>::get_nu() const {
+  return nu_;
+}
+
+template <typename Scalar>
+const std::size_t& ConstraintModelManagerTpl<Scalar>::get_ng() const {
+  return ng_;
+}
+
+template <typename Scalar>
+const std::size_t& ConstraintModelManagerTpl<Scalar>::get_ng_total() const {
+  return ng_total_;
+}
+
+template <typename Scalar>
+const std::size_t& ConstraintModelManagerTpl<Scalar>::get_nh() const {
+  return nh_;
+}
+
+template <typename Scalar>
+const std::size_t& ConstraintModelManagerTpl<Scalar>::get_nh_total() const {
+  return nh_total_;
+}
+
+template <typename Scalar>
+const std::vector<std::string>& ConstraintModelManagerTpl<Scalar>::get_active() const {
+  return active_;
+}
+
+template <typename Scalar>
+const std::vector<std::string>& ConstraintModelManagerTpl<Scalar>::get_inactive() const {
+  return inactive_;
+}
+
+template <typename Scalar>
+bool ConstraintModelManagerTpl<Scalar>::getConstraintStatus(const std::string& name) const {
+  typename ConstraintModelContainer::const_iterator it = constraints_.find(name);
+  if (it != constraints_.end()) {
+    return it->second->active;
+  } else {
+    std::cout << "Warning: we couldn't get the status of the " << name << " constraint item, it doesn't exist."
+              << std::endl;
+    return false;
+  }
+}
+
+}  // namespace crocoddyl

--- a/include/crocoddyl/core/cost-base.hpp
+++ b/include/crocoddyl/core/cost-base.hpp
@@ -16,7 +16,6 @@
 #include "crocoddyl/core/state-base.hpp"
 #include "crocoddyl/core/data-collector-base.hpp"
 #include "crocoddyl/core/activation-base.hpp"
-#include "crocoddyl/core/utils/to-string.hpp"
 #include "crocoddyl/core/activations/quadratic.hpp"
 
 namespace crocoddyl {

--- a/include/crocoddyl/core/costs/cost-sum.hpp
+++ b/include/crocoddyl/core/costs/cost-sum.hpp
@@ -38,7 +38,7 @@ struct CostItemTpl {
 };
 
 /**
- * @brief Sumation of individual cost models
+ * @brief Summation of individual cost models
  *
  * This class serves to manage a set of added cost models. The cost functions might active or inactive, with this
  * approach we avoid dynamic allocation of memory. Each cost model is added through `addCost`, where the weight and its

--- a/include/crocoddyl/core/costs/cost-sum.hpp
+++ b/include/crocoddyl/core/costs/cost-sum.hpp
@@ -123,7 +123,7 @@ class CostModelSumTpl {
    * @param[in] x     State point \f$\mathbf{x}\in\mathbb{R}^{ndx}\f$
    * @param[in] u     Control input \f$\mathbf{u}\in\mathbb{R}^{nu}\f$
    */
-  void calc(const boost::shared_ptr<CostDataSumTpl<Scalar> >& data, const Eigen::Ref<const VectorXs>& x,
+  void calc(const boost::shared_ptr<CostDataSum>& data, const Eigen::Ref<const VectorXs>& x,
             const Eigen::Ref<const VectorXs>& u);
 
   /**
@@ -133,7 +133,7 @@ class CostModelSumTpl {
    * @param[in] x     State point \f$\mathbf{x}\in\mathbb{R}^{ndx}\f$
    * @param[in] u     Control input \f$\mathbf{u}\in\mathbb{R}^{nu}\f$
    */
-  void calcDiff(const boost::shared_ptr<CostDataSumTpl<Scalar> >& data, const Eigen::Ref<const VectorXs>& x,
+  void calcDiff(const boost::shared_ptr<CostDataSum>& data, const Eigen::Ref<const VectorXs>& x,
                 const Eigen::Ref<const VectorXs>& u);
 
   /**
@@ -146,7 +146,7 @@ class CostModelSumTpl {
    * @param data  Data collector
    * @return the cost data
    */
-  boost::shared_ptr<CostDataSumTpl<Scalar> > createData(DataCollectorAbstract* const data);
+  boost::shared_ptr<CostDataSum> createData(DataCollectorAbstract* const data);
 
   /**
    * @copybrief calc()
@@ -154,7 +154,7 @@ class CostModelSumTpl {
    * @param[in] data  Cost data
    * @param[in] x     State point
    */
-  void calc(const boost::shared_ptr<CostDataSumTpl<Scalar> >& data, const Eigen::Ref<const VectorXs>& x);
+  void calc(const boost::shared_ptr<CostDataSum>& data, const Eigen::Ref<const VectorXs>& x);
 
   /**
    * @copybrief calcDiff()
@@ -162,7 +162,7 @@ class CostModelSumTpl {
    * @param[in] data  Cost data
    * @param[in] x     State point
    */
-  void calcDiff(const boost::shared_ptr<CostDataSumTpl<Scalar> >& data, const Eigen::Ref<const VectorXs>& x);
+  void calcDiff(const boost::shared_ptr<CostDataSum>& data, const Eigen::Ref<const VectorXs>& x);
 
   /**
    * @brief Return the state

--- a/include/crocoddyl/core/costs/cost-sum.hpp
+++ b/include/crocoddyl/core/costs/cost-sum.hpp
@@ -51,7 +51,7 @@ struct CostItemTpl {
  * \f$\mathbf{l_{xx}}\in\mathbb{R}^{ndx\times ndx}\f$, \f$\mathbf{l_{xu}}\in\mathbb{R}^{ndx\times nu}\f$,
  * \f$\mathbf{l_{uu}}\in\mathbb{R}^{nu\times nu}\f$ are the Jacobians and Hessians, respectively.
  *
- * \sa `StateAbstractTpl`, `ActivationModelAbstractTpl`, `calc()`, `calcDiff()`, `createData()`
+ * \sa `StateAbstractTpl`, `calc()`, `calcDiff()`, `createData()`
  */
 template <typename _Scalar>
 class CostModelSumTpl {
@@ -180,7 +180,7 @@ class CostModelSumTpl {
   const std::size_t& get_nu() const;
 
   /**
-   * @brief Return the dimension of the actived residual vector
+   * @brief Return the dimension of the active residual vector
    */
   const std::size_t& get_nr() const;
 

--- a/include/crocoddyl/core/fwd.hpp
+++ b/include/crocoddyl/core/fwd.hpp
@@ -136,6 +136,12 @@ struct CostDataSumTpl;
 template <typename Scalar>
 class CostModelControlTpl;
 
+// constraint
+template <typename Scalar>
+class ConstraintModelAbstractTpl;
+template <typename Scalar>
+struct ConstraintDataAbstractTpl;
+
 // shooting
 template <typename Scalar>
 class ShootingProblemTpl;
@@ -225,6 +231,9 @@ typedef CostItemTpl<double> CostItem;
 typedef CostModelSumTpl<double> CostModelSum;
 typedef CostDataSumTpl<double> CostDataSum;
 typedef CostModelControlTpl<double> CostModelControl;
+
+typedef ConstraintModelAbstractTpl<double> ConstraintModelAbstract;
+typedef ConstraintDataAbstractTpl<double> ConstraintDataAbstract;
 
 typedef ShootingProblemTpl<double> ShootingProblem;
 

--- a/include/crocoddyl/core/fwd.hpp
+++ b/include/crocoddyl/core/fwd.hpp
@@ -142,6 +142,13 @@ class ConstraintModelAbstractTpl;
 template <typename Scalar>
 struct ConstraintDataAbstractTpl;
 
+template <typename Scalar>
+struct ConstraintItemTpl;
+template <typename Scalar>
+class ConstraintModelManagerTpl;
+template <typename Scalar>
+struct ConstraintDataManagerTpl;
+
 // shooting
 template <typename Scalar>
 class ShootingProblemTpl;
@@ -234,6 +241,9 @@ typedef CostModelControlTpl<double> CostModelControl;
 
 typedef ConstraintModelAbstractTpl<double> ConstraintModelAbstract;
 typedef ConstraintDataAbstractTpl<double> ConstraintDataAbstract;
+typedef ConstraintItemTpl<double> ConstraintItem;
+typedef ConstraintModelManagerTpl<double> ConstraintModelManager;
+typedef ConstraintDataManagerTpl<double> ConstraintDataManager;
 
 typedef ShootingProblemTpl<double> ShootingProblem;
 


### PR DESCRIPTION
This PR includes two classes: 
   1) constraint abstract: it allows us to derived constraint models and datas
   2) constraint manager: it allows us to manage a number of single constraints (similarly to cost sum)

I have also created Python bindings of both classes. However, there is no yet unittest code.
To do this latter thing, I will need to integrate many different constraint models which I will handle in another PR.

@PepMS has a look of this PR. Let me know if you would like to discuss about it. You could also add your comments in this PR.